### PR TITLE
Error Building

### DIFF
--- a/mdb-slave-esp32s3/main/mdb-slave-esp32s3.c
+++ b/mdb-slave-esp32s3/main/mdb-slave-esp32s3.c
@@ -23,6 +23,7 @@
 
 #include "bleprph.h"
 #include "nimble.h"
+#include <time.h>
 
 #define TAG "mdb-target"
 


### PR DESCRIPTION
Error when Build.

The standard header <time.h> belongs to the C language library. It defines structures, types, and functions related to system time.

<img width="1889" height="652" alt="Screenshot 2025-11-05 144256" src="https://github.com/user-attachments/assets/c90353fe-900b-40d0-975c-663f6270025b" />
