### PR TITLE
updated WiFi Password to accept longer Passwords

### DIFF
--- a/Android/app/src/main/java/xyz/vmflow/NearestFragment.java
+++ b/Android/app/src/main/java/xyz/vmflow/NearestFragment.java
@@ -306,7 +306,7 @@ public class NearestFragment extends Fragment {
                         payloadSsid[1 + arrSsid.length] = 0x00;
                     }
 
-                    byte[] payloadPswd = new byte[22];
+                    byte[] payloadPswd = new byte[63];
                     {
                         byte[] arrPswd = password.getBytes(StandardCharsets.UTF_8);
 


### PR DESCRIPTION
The App crashed if you wanted to enter a longer password. I extended the password length capability